### PR TITLE
Add near-exact match handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ This repository contains a single Google Ads Script (`negatif.js`) that automati
 3. Review the configuration constants at the top of the `main` function and adjust if necessary.
 4. Authorize and run the script, or schedule it to run periodically.
 
-The script is case-sensitive; the terms "iphone" and "iPhone" are treated as different queries. A shared negative keyword list named `Script Liste` is created or replaced each run.
+The script is case-sensitive; the terms "iphone" and "iPhone" are treated as different queries. It now looks at both exact matches and their close variants. A shared negative keyword list named `Script Liste` is created or replaced each run.
 
 ## License
 This project is licensed under the MIT License. See [LICENSE](LICENSE) for details.

--- a/negatif.js
+++ b/negatif.js
@@ -74,7 +74,7 @@ function collectEnhancedData(daysBack, conv1, conv2, waConv) {
            metrics.impressions
     FROM   search_term_view
     WHERE  segments.date BETWEEN '${s}' AND '${e}'
-      AND  segments.search_term_match_type = 'EXACT'
+      AND  segments.search_term_match_type IN ('EXACT','NEAR_EXACT')
       AND  metrics.impressions > 0`;
 
   const it1 = AdsApp.report(q1).rows();
@@ -131,7 +131,7 @@ function collectEnhancedData(daysBack, conv1, conv2, waConv) {
            metrics.conversions_value
     FROM   search_term_view
     WHERE  segments.date BETWEEN '${s}' AND '${e}'
-      AND  segments.search_term_match_type = 'EXACT'
+      AND  segments.search_term_match_type IN ('EXACT','NEAR_EXACT')
       AND  metrics.all_conversions > 0`;
 
   const it2 = AdsApp.report(q2).rows();
@@ -391,7 +391,7 @@ function sendEnhancedReport(analysis, emailTo, testMode, sync, listName) {
        '<em>(' + listName + ')</em>');
 
   // Uyarı kutusu
-  html += createBox('#d4edda', '#198754', '<strong>✅ BÜYÜK/KÜÇÜK HARFE DUYARLI:</strong> Arama terimleri tam eşleşme ile analiz edildi.');
+  html += createBox('#d4edda', '#198754', '<strong>✅ BÜYÜK/KÜÇÜK HARFE DUYARLI:</strong> Arama terimleri tam eşleşme ve yakın varyasyonlarıyla analiz edildi.');
 
   // KPI tablosu
   html += '<table style="width:100%;border-collapse:collapse;background:#f8f9fa;border-radius:6px;margin-bottom:22px;"><tr>' +
@@ -476,7 +476,7 @@ function sendEnhancedReport(analysis, emailTo, testMode, sync, listName) {
   }
 
   html += '<p style="margin-top:30px;padding:15px;background:#e9ecef;border-radius:5px;font-size:12px;color:#495057;">' +
-          '🔧 Script çalışma modu: BÜYÜK/KÜÇÜK HARFE DUYARLI - Arama terimleri tam eşleşme ile analiz edildi<br>' +
+          '🔧 Script çalışma modu: BÜYÜK/KÜÇÜK HARFE DUYARLI - Arama terimleri tam eşleşme ve yakın varyasyonlarıyla analiz edildi<br>' +
           '📊 Analiz aralığı: Son 60 gün | Min. maliyet: ₺50 | Max CPA: ₺400<br>' +
           '🔤 "iPhone" ve "iphone" farklı terimler olarak değerlendirildi<br>' +
           '⚙️ Negatif liste: "' + listName + '" | Rapor: ' + dateStr + '</p>' +


### PR DESCRIPTION
## Summary
- include search term match type `NEAR_EXACT`
- document that close variants are now included

## Testing
- `node --check negatif.js`


------
https://chatgpt.com/codex/tasks/task_e_684aacaf3554832785c5530633ea6354